### PR TITLE
fix(types): use typesVersions to map the types for non module resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,5 +63,15 @@
       "./credentials": "./src/credentials/index.ts",
       "./package.json": "./package.json"
     }
+  },
+  "typesVersions": {
+    "*": {
+      "api": [
+        "dist/commonjs/api/index.d.ts"
+      ],
+      "credentials": [
+        "dist/commonjs/credentials/index.d.ts"
+      ]
+    }
   }
 }


### PR DESCRIPTION
This fixes #372.