### PR TITLE
docs(README.md): revamp the goal section

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ If you want to use `passport js` and OAuth 2.0 introspection, head over to
 
 ## Goals
 
-This is the "client library" for the ZITADEL API. It contains the compiled
+This is meant to be a Node.js SDK for the ZITADEL API. It contains the compiled
 proto files from the original ZITADEL repository and therefore helps to
-access the API and manage ressources. Also, it contains helpers to
+access the API and manage resources. Moreover, it contains helpers to
 authenticate a given service account against ZITADEL.
 
 To summarize:


### PR DESCRIPTION
Remove dangerous wording "client" because this library is not meant to be within the node runtime and serves as a SDK.